### PR TITLE
Set same logger format for luigi and our project.

### DIFF
--- a/{{ cookiecutter.repo_name }}/conf/luigi-logging.cfg
+++ b/{{ cookiecutter.repo_name }}/conf/luigi-logging.cfg
@@ -38,5 +38,5 @@ level=DEBUG
 args=(sys.stdout,)
 
 [formatter_default]
-format=%(asctime)s %(levelname)-8s %(name)-15s %(message)s
+format=%(asctime)s %(name)-26s %(levelname)-7s %(message)s
 datefmt=%Y-%m-%d %H:%M:%S

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name }}/logging.yml
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name }}/logging.yml
@@ -30,7 +30,7 @@ handlers:
 formatters:
   simple:
     class: logging.Formatter
-    format: '%(name)s %(asctime)s %(levelname)s %(message)s'
+    format: '%(asctime)s %(name)-26s %(levelname)-7s %(message)s'
     datefmt: '%Y-%m-%d %H:%M:%S'
   container:
     class: logging.Formatter


### PR DESCRIPTION
%(name)-26s is because drtools.learn.model.neural has 26 letters and it
always displays a warning ;)

%(levelname)-7s is because WARNING has 7 letters. CRITICAL has more,
but it should be last message, so it doesn't have to be pretty.